### PR TITLE
Renamed command handler parameter from 'event' to 'command'

### DIFF
--- a/tests/server_module.integration.coffee
+++ b/tests/server_module.integration.coffee
@@ -155,9 +155,9 @@ class CustomerRegistrationRouter extends Space.messaging.Controller
     repository: 'Space.cqrs.Repository'
     registrations: 'CustomerRegistrations'
 
-  @handle CustomerApp.RegisterCustomer, on: (event) ->
+  @handle CustomerApp.RegisterCustomer, on: (command) ->
 
-    registration = new CustomerRegistration event.registrationId, event
+    registration = new CustomerRegistration command.registrationId, command
     @repository.save registration, registration.getVersion()
 
   @handle CustomerApp.CustomerCreated, on: (event) ->


### PR DESCRIPTION
This is just a minor tweak for clarity considering the integration test is the only example